### PR TITLE
Normalize pipeline output for model input

### DIFF
--- a/backend/app/pipeline.py
+++ b/backend/app/pipeline.py
@@ -1,11 +1,25 @@
 import cv2
 import numpy as np
+from typing import Dict, Optional, Tuple
+
 from core.io import to_bgr, to_gray
 from core.denoise import median_filter
 from core.mask import apply_circular_mask
 
 
-def run_pipeline(file_bytes: bytes):
+def _resize(image: np.ndarray, output_size: Tuple[int, int]) -> np.ndarray:
+    """Resize the provided image to the desired output size."""
+    if image is None:
+        return image
+
+    width, height = output_size
+    return cv2.resize(image, (width, height), interpolation=cv2.INTER_AREA)
+
+
+def run_pipeline(
+    file_bytes: bytes,
+    output_size: Optional[Tuple[int, int]] = (224, 224),
+) -> Dict[str, np.ndarray]:
     # 1. Load and convert
     bgr = to_bgr(file_bytes)
     gray = to_gray(bgr)
@@ -24,6 +38,16 @@ def run_pipeline(file_bytes: bytes):
         maxRadius=1200
     )
 
-    final_image = apply_circular_mask(bgr, circles)
+    masked_bgr = apply_circular_mask(bgr, circles)
+    masked_gray = apply_circular_mask(gray, circles)
 
-    return final_image
+    if output_size is not None:
+        masked_bgr = _resize(masked_bgr, output_size)
+        masked_gray = _resize(masked_gray, output_size)
+
+    rgb_image = cv2.cvtColor(masked_bgr, cv2.COLOR_BGR2RGB)
+    rgb_image = rgb_image.astype(np.float32) / 255.0
+
+    gray_image = masked_gray.astype(np.float32) / 255.0
+
+    return {"rgb": rgb_image, "gray": gray_image}

--- a/backend/app/test_pipeline.py
+++ b/backend/app/test_pipeline.py
@@ -1,14 +1,42 @@
-import cv2
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+cv2 = pytest.importorskip("cv2", reason="requires OpenCV", exc_type=ImportError)
+
 from app.pipeline import run_pipeline
 
-img_path = "./app/13895.jpg"
 
-with open(img_path, "rb") as f:
-    file_bytes = f.read()
+def test_run_pipeline_returns_normalized_rgb_and_gray_images():
+    img_path = Path(__file__).parent / "13895.jpg"
+    file_bytes = img_path.read_bytes()
 
-result = run_pipeline(file_bytes)
+    result = run_pipeline(file_bytes)
 
-cv2.namedWindow("Result", cv2.WINDOW_NORMAL)
-cv2.imshow("Result", result)
-cv2.waitKey(0)
-cv2.destroyAllWindows()
+    assert set(result.keys()) == {"rgb", "gray"}
+
+    rgb = result["rgb"]
+    assert rgb.shape == (224, 224, 3)
+    assert rgb.dtype == np.float32
+    assert np.all(rgb >= 0.0)
+    assert np.all(rgb <= 1.0)
+
+    gray = result["gray"]
+    assert gray.shape == (224, 224)
+    assert gray.dtype == np.float32
+    assert np.all(gray >= 0.0)
+    assert np.all(gray <= 1.0)
+
+
+def test_run_pipeline_respects_custom_output_size():
+    img_path = Path(__file__).parent / "13895.jpg"
+    file_bytes = img_path.read_bytes()
+
+    result = run_pipeline(file_bytes, output_size=(128, 128))
+
+    rgb = result["rgb"]
+    assert rgb.shape == (128, 128, 3)
+
+    gray = result["gray"]
+    assert gray.shape == (128, 128)


### PR DESCRIPTION
## Summary
- convert the pipeline output to normalized RGB tensors and expose a configurable resize
- return the masked grayscale slice alongside the RGB data for single-channel consumers
- add pytest coverage to verify output tensor shapes and types

## Testing
- pytest backend/app -q

------
https://chatgpt.com/codex/tasks/task_e_68fbbf48e44883218ec5941459306f05