### PR TITLE
Adjust Hough circle parameters based on image dimensions

### DIFF
--- a/backend/app/pipeline.py
+++ b/backend/app/pipeline.py
@@ -1,11 +1,27 @@
 import cv2
-import numpy as np
 from core.io import to_bgr, to_gray
 from core.denoise import median_filter
 from core.mask import apply_circular_mask
 
 
-def run_pipeline(file_bytes: bytes):
+DEFAULT_DP = 1.2
+DEFAULT_MIN_DIST_FRACTION = 0.5
+DEFAULT_MIN_RADIUS_FRACTION = 0.35
+DEFAULT_MAX_RADIUS_FRACTION = 0.65
+DEFAULT_PARAM1 = 150
+DEFAULT_PARAM2 = 50
+
+
+def run_pipeline(
+    file_bytes: bytes,
+    *,
+    dp: float = DEFAULT_DP,
+    min_dist_fraction: float = DEFAULT_MIN_DIST_FRACTION,
+    min_radius_fraction: float = DEFAULT_MIN_RADIUS_FRACTION,
+    max_radius_fraction: float = DEFAULT_MAX_RADIUS_FRACTION,
+    param1: float = DEFAULT_PARAM1,
+    param2: float = DEFAULT_PARAM2,
+):
     # 1. Load and convert
     bgr = to_bgr(file_bytes)
     gray = to_gray(bgr)
@@ -13,15 +29,27 @@ def run_pipeline(file_bytes: bytes):
     # 2. Denoise
     gray_blurred = median_filter(gray, 25)
 
+    height, width = gray_blurred.shape[:2]
+    min_dimension = min(height, width)
+
+    min_dist = min_dimension * min_dist_fraction
+    min_radius = max(1.0, min_dimension * min_radius_fraction)
+    max_radius = max(min_radius + 1.0, min_dimension * max_radius_fraction)
+
+    min_radius_int = int(round(min_radius))
+    max_radius_int = int(round(max_radius))
+    if max_radius_int <= min_radius_int:
+        max_radius_int = min_radius_int + 1
+
     circles = cv2.HoughCircles(
         image=gray_blurred,
         method=cv2.HOUGH_GRADIENT,
-        dp=1.2,
-        minDist=1000,
-        param1=100,
-        param2=80,
-        minRadius=800,
-        maxRadius=1200
+        dp=dp,
+        minDist=min_dist,
+        param1=param1,
+        param2=param2,
+        minRadius=min_radius_int,
+        maxRadius=max_radius_int,
     )
 
     final_image = apply_circular_mask(bgr, circles)

--- a/backend/app/test_pipeline.py
+++ b/backend/app/test_pipeline.py
@@ -1,14 +1,170 @@
+import sys
+import types
+
+import numpy as np
+import pytest
+
+
+if "cv2" not in sys.modules:
+    cv2_stub = types.SimpleNamespace()
+
+    cv2_stub.HOUGH_GRADIENT = 0
+    cv2_stub.COLOR_BGR2GRAY = 6
+
+    def circle(image, center, radius, color, thickness):
+        if thickness != -1:
+            raise NotImplementedError("Stub only supports filled circles")
+        cx, cy = center
+        yy, xx = np.ogrid[: image.shape[0], : image.shape[1]]
+        mask = (xx - cx) ** 2 + (yy - cy) ** 2 <= radius ** 2
+        image[mask] = color
+        return image
+
+    def bitwise_and(src1, src2, mask=None):
+        result = np.bitwise_and(src1, src2)
+        if mask is None:
+            return result
+        mask_bool = mask.astype(bool)
+        if mask_bool.ndim == 2 and result.ndim == 3:
+            mask_bool = mask_bool[..., np.newaxis]
+        return np.where(mask_bool, result, 0)
+
+    cv2_stub.circle = circle
+    cv2_stub.bitwise_and = bitwise_and
+    cv2_stub.HoughCircles = None
+
+    sys.modules["cv2"] = cv2_stub
+
 import cv2
-from app.pipeline import run_pipeline
 
-img_path = "./app/13895.jpg"
+import app.pipeline as pipeline
+from app.pipeline import (
+    DEFAULT_DP,
+    DEFAULT_MAX_RADIUS_FRACTION,
+    DEFAULT_MIN_DIST_FRACTION,
+    DEFAULT_MIN_RADIUS_FRACTION,
+    DEFAULT_PARAM1,
+    DEFAULT_PARAM2,
+    run_pipeline,
+)
 
-with open(img_path, "rb") as f:
-    file_bytes = f.read()
 
-result = run_pipeline(file_bytes)
+def _expected_radius_bounds(
+    min_dimension: int,
+    min_fraction: float = DEFAULT_MIN_RADIUS_FRACTION,
+    max_fraction: float = DEFAULT_MAX_RADIUS_FRACTION,
+):
+    min_radius = max(1.0, min_dimension * min_fraction)
+    max_radius = max(min_radius + 1.0, min_dimension * max_fraction)
 
-cv2.namedWindow("Result", cv2.WINDOW_NORMAL)
-cv2.imshow("Result", result)
-cv2.waitKey(0)
-cv2.destroyAllWindows()
+    min_radius_int = int(round(min_radius))
+    max_radius_int = int(round(max_radius))
+    if max_radius_int <= min_radius_int:
+        max_radius_int = min_radius_int + 1
+
+    return min_radius_int, max_radius_int
+
+
+def _prepare_monkeypatched_io(monkeypatch, bgr_image: np.ndarray):
+    gray_image = bgr_image.mean(axis=2).astype(np.uint8)
+    monkeypatch.setattr(pipeline, "to_bgr", lambda _: bgr_image.copy())
+    monkeypatch.setattr(pipeline, "to_gray", lambda _: gray_image.copy())
+    monkeypatch.setattr(pipeline, "median_filter", lambda image, ksize=25: gray_image.copy())
+
+
+def test_run_pipeline_applies_mask_across_multiple_sizes(monkeypatch):
+    captured_calls = []
+
+    def fake_hough(image, method, dp, minDist, param1, param2, minRadius, maxRadius):
+        height, width = image.shape[:2]
+        captured_calls.append(
+            {
+                "shape": (height, width),
+                "dp": dp,
+                "minDist": minDist,
+                "param1": param1,
+                "param2": param2,
+                "minRadius": minRadius,
+                "maxRadius": maxRadius,
+            }
+        )
+        radius = max(1, min(height, width) // 4)
+        center = (width // 2, height // 2, radius)
+        return np.array([[center]], dtype=np.float32)
+
+    monkeypatch.setattr(cv2, "HoughCircles", fake_hough)
+
+    sizes = ((400, 400), (320, 500), (512, 256))
+    for height, width in sizes:
+        bgr_image = np.full((height, width, 3), 200, dtype=np.uint8)
+        _prepare_monkeypatched_io(monkeypatch, bgr_image)
+
+        result = run_pipeline(b"unused")
+
+        assert result.shape == (height, width, 3)
+        assert np.count_nonzero(result) < result.size
+
+    assert len(captured_calls) == len(sizes)
+
+    for call, (height, width) in zip(captured_calls, sizes):
+        min_dimension = min(height, width)
+        expected_min_dist = min_dimension * DEFAULT_MIN_DIST_FRACTION
+        expected_min_radius, expected_max_radius = _expected_radius_bounds(min_dimension)
+
+        assert call["shape"] == (height, width)
+        assert call["dp"] == DEFAULT_DP
+        assert call["param1"] == DEFAULT_PARAM1
+        assert call["param2"] == DEFAULT_PARAM2
+        assert call["minDist"] == pytest.approx(expected_min_dist)
+        assert call["minRadius"] == expected_min_radius
+        assert call["maxRadius"] == expected_max_radius
+
+
+def test_run_pipeline_accepts_custom_circle_parameters(monkeypatch):
+    captured_args = {}
+
+    def fake_hough(image, method, dp, minDist, param1, param2, minRadius, maxRadius):
+        captured_args.update(
+            {
+                "dp": dp,
+                "minDist": minDist,
+                "param1": param1,
+                "param2": param2,
+                "minRadius": minRadius,
+                "maxRadius": maxRadius,
+            }
+        )
+        height, width = image.shape[:2]
+        radius = max(1, min(height, width) // 5)
+        center = (width // 2, height // 2, radius)
+        return np.array([[center]], dtype=np.float32)
+
+    monkeypatch.setattr(cv2, "HoughCircles", fake_hough)
+
+    custom_kwargs = {
+        "dp": 1.5,
+        "min_dist_fraction": 0.2,
+        "min_radius_fraction": 0.1,
+        "max_radius_fraction": 0.3,
+        "param1": 180,
+        "param2": 45,
+    }
+
+    bgr_image = np.full((300, 450, 3), 180, dtype=np.uint8)
+    _prepare_monkeypatched_io(monkeypatch, bgr_image)
+
+    run_pipeline(b"unused", **custom_kwargs)
+
+    min_dimension = min(300, 450)
+    expected_min_radius, expected_max_radius = _expected_radius_bounds(
+        min_dimension,
+        min_fraction=custom_kwargs["min_radius_fraction"],
+        max_fraction=custom_kwargs["max_radius_fraction"],
+    )
+
+    assert captured_args["dp"] == custom_kwargs["dp"]
+    assert captured_args["minDist"] == pytest.approx(min_dimension * custom_kwargs["min_dist_fraction"])
+    assert captured_args["param1"] == custom_kwargs["param1"]
+    assert captured_args["param2"] == custom_kwargs["param2"]
+    assert captured_args["minRadius"] == expected_min_radius
+    assert captured_args["maxRadius"] == expected_max_radius


### PR DESCRIPTION
## Summary
- compute Hough circle distance and radius thresholds as fractions of the gray image size and expose them as configurable parameters
- ensure radius bounds stay valid before applying the circular mask
- replace the interactive OpenCV smoke test with pytest coverage that exercises multiple image sizes and custom parameters while stubbing OpenCV

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fbbf305fd48321bac4f16bf6bb5a71